### PR TITLE
 Disable LDAP authentication via an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ search through the paths given with `-d` in order to find a match.
 1. `cp config/import.yml.template config/import.yml`
 1. `rails s` to run rails server
 
+### Use database authentication instead of LDAP
+If you want to use spotlight's built-in database authentication instead of LDAP,
+either for local development or on a DCE server, set an environment variable in
+.env.development or .env.production:
+`DATABASE_AUTH=true`
+
 ### Set up a local admin account
 1. Self-register in the web ui
 1. Run this rake command: `rake spotlight:admin`

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -326,8 +326,12 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  config.warden do |manager|
-    manager.default_strategies(scope: :user).unshift :ldap_authenticatable
+
+  ## Set DATABASE_AUTH=true to use local database authentication instead of LDAP
+  unless ENV['DATABASE_AUTH']
+    config.warden do |manager|
+      manager.default_strategies(scope: :user).unshift :ldap_authenticatable
+    end
   end
 
   # ==> Mountable engine configurations


### PR DESCRIPTION
Some environments (e.g., DCE servers) will need to use
local database authentication instead of LDAP.  Use
an environment variable (DATABASE_AUTH) to switch this
behavior and document this in the README.

Unless the variable is set, LDAP auth is assumed, so this
shouldn't change any behavior in the UCSB environment.