### PR TITLE
Allow PDF uploads

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -89,7 +89,7 @@
 # ]
 # Spotlight::Engine.config.upload_title_field = nil # Spotlight::UploadFieldConfig.new(...)
 # Spotlight::Engine.config.uploader_storage = :file
-Spotlight::Engine.config.allowed_upload_extensions = %w[jpg jpeg png tif tiff]
+Spotlight::Engine.config.allowed_upload_extensions = %w[jpg jpeg png tif tiff pdf]
 Spotlight::Engine.config.upload_dir = Rails.root.join('public', 'uploads')
 
 # Spotlight::Engine.config.featured_image_thumb_size = [400, 300]


### PR DESCRIPTION
This setting allows PDFs to be uploaded
in the interface and via a CSV.

Connected to #18