### PR TITLE
Setup Docker images and a `docker-compose` for development

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,2 @@
+DATABASE_AUTH=true
+SOLR_URL=http://solr:8983/solr/geniza

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.5.3
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get update -qq && \
+    apt-get install -qq -y --no-install-recommends \
+    build-essential \
+    nodejs \
+    libpq-dev \
+    git \
+    tzdata \
+    libxml2-dev \
+    libxslt-dev \
+    ssh \
+    libsqlite3-dev \
+    sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /data
+WORKDIR /data
+ADD . /data
+ENV BUNDLE_JOBS=4
+RUN bundle install
+RUN bundle exec rake db:migrate
+EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '2.2'
+services:
+  main:
+    build: .
+    env_file:
+      - .env.docker
+    volumes:
+      - .:/data
+
+  web:
+    extends: main
+    command: bundle exec rails s
+    ports:
+      - "3000:3000"
+    depends_on:
+      - solr
+
+  solr:
+    image: solr:7.1
+    ports:
+      - "8983:8983"
+    volumes:
+      - './solr/config:/opt/config'
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - geniza
+      - /opt/config
+
+volumes:
+  solr:


### PR DESCRIPTION
This represents an alternative development environment using Docker to manage
needed services and startup the server.

To run the development environment with docker, do `docker-compose up`.

You can run commands within the `web` application container with `docker-compose
exec web [command]`; e.g. `docker-compose exec web bundle exec rake db:setup`.

The test suite can be run with `docker-compose exec web bundle exec rspec`, but
currently fails due to missing `chromedriver` dependencies.