### PR TITLE
Upgrade Rack to 2.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
       yard (~> 0.9.11)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)


### PR DESCRIPTION
Addresses CVE-2018-16471 and CVE-2018-16470.